### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,8 +125,6 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @items != nil %>
       <li class='list'>
       <% @items.each do |item| %>
@@ -143,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -156,10 +154,8 @@
         <% end %>
       <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% else %>
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -177,7 +173,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
       <% end %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,7 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-      <% if @items != nil %>
+      <% if @items != [] %>
       <li class='list'>
       <% @items.each do |item| %>
         <%= link_to "#" do %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
       it 'priceは半角数字のみ登録可能' do
-        @item.price = "１２３４"
+        @item.price = '１２３４'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'ユーザーが紐づいていなければ登録できない' do
         @item.user = nil


### PR DESCRIPTION
# What
商品一覧表示機能の実装
- 商品のnameとpriceを表示
- 商品の並び替えは商品出品機能のところでやってしまいました
## 修正後の機能の様子
Gyazoのurl: https://gyazo.com/80250c4887ef0658c366664fe3d87536

# Why
商品一覧表示機能を実装するため